### PR TITLE
sm8250-common: Build android.media.audio.common.types-V2-cpp

### DIFF
--- a/kona.mk
+++ b/kona.mk
@@ -501,6 +501,7 @@ PRODUCT_COPY_FILES += \
 
 # Wi-Fi Display
 PRODUCT_PACKAGES += \
+    android.media.audio.common.types-V2-cpp \
     libnl \
     libwfdaac_vendor
 


### PR DESCRIPTION
Needed for WFD, and not built default on QPR2

Change-Id: If860613ef4cb6bae7f7a7e72707c24510e36abd6